### PR TITLE
Make shell mode colors match term

### DIFF
--- a/rebecca-theme.el
+++ b/rebecca-theme.el
@@ -474,9 +474,13 @@
    `(icicle-complete-input                     ((,class (:foreground ,builtin))))
    `(icicle-common-match-highlight-Completions ((,class (:foreground ,type))))
    `(icicle-candidate-part                     ((,class (:foreground ,var))))
-   `(icicle-annotation                         ((,class (:foreground ,fg4))))
-   ))
+   `(icicle-annotation                         ((,class (:foreground ,fg4)))))
 
+  (custom-theme-set-variables
+   'rebecca
+   `(ansi-color-names-vector [(,bg3 ,bg3) (,keyword ,bg3) (,type ,bg3)
+			      (,var ,var) (,func ,func) (,builtin ,builtin)
+			      (,str ,str) (,fg2 ,fg2)])))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Love this theme. Thanks for making it.

This patch just makes the shell mode colors match those in term mode. Previously, shell mode ended up having the default colors which are tough to read in the context of the rest of the theme.